### PR TITLE
Updated call to deprecated item_thumbnail()

### DIFF
--- a/helpers/ItemGoogleMap.php
+++ b/helpers/ItemGoogleMap.php
@@ -31,7 +31,7 @@ class Geolocation_View_Helper_ItemGoogleMap extends Zend_View_Helper_Abstract
             $center['show']         = true;
             if ($hasBalloonForMarker) {
                 $titleLink = link_to_item(metadata($item, array('Dublin Core', 'Title'), array(), $item), array(), 'show', $item);
-                $thumbnailLink = !(item_image('thumbnail')) ? '' : link_to_item(item_thumbnail(array(), 0, $item), array(), 'show', $item);
+                $thumbnailLink = !(item_image('thumbnail')) ? '' : link_to_item(item_image('thumbnail',array(), 0, $item), array(), 'show', $item);
                 $description = metadata($item, array('Dublin Core', 'Description'), array('snippet'=>150), $item);
                 //$center['markerHtml']   = geolocation_get_marker_html_for_item($item, $markerHtmlClassName);
                 $center['markerHtml'] = '<div class="' . $markerHtmlClassName . '"><p class="geolocation_marker_title">' . $titleLink . '</p>' . $thumbnailLink . '<p>' . $description . '</p></div>';


### PR DESCRIPTION
This broke when I installed it on our Omeka 2.0. Seems like it was just overlooked on all the updates. 
