### PR TITLE
Add option to disable images in browse.kml.php 

### DIFF
--- a/GeolocationPlugin.php
+++ b/GeolocationPlugin.php
@@ -83,7 +83,9 @@ class GeolocationPlugin extends Omeka_Plugin_AbstractPlugin
         set_option('geolocation_default_longitude', '-77');
         set_option('geolocation_default_zoom_level', '5');
         set_option('geolocation_per_page', GEOLOCATION_DEFAULT_LOCATIONS_PER_PAGE);
-        set_option('geolocation_add_map_to_contribution_form', '1');        
+        set_option('geolocation_add_map_to_contribution_form', '1'); 
+        
+        set_option('geolocation_disable_images', '0');        
     }
     
     public function hookUninstall()
@@ -94,6 +96,8 @@ class GeolocationPlugin extends Omeka_Plugin_AbstractPlugin
         delete_option('geolocation_default_zoom_level');
         delete_option('geolocation_per_page');
         delete_option('geolocation_add_map_to_contribution_form');
+        
+        delete_option('geolocation_disable_images');
         
         // This is for older versions of Geolocation, which used to store a Google Map API key.
         delete_option('geolocation_gmaps_key');
@@ -135,7 +139,9 @@ class GeolocationPlugin extends Omeka_Plugin_AbstractPlugin
         }
         set_option('geolocation_per_page', $perPage);
         set_option('geolocation_add_map_to_contribution_form', $_POST['geolocation_add_map_to_contribution_form']);
-        set_option('geolocation_link_to_nav', $_POST['geolocation_link_to_nav']);        
+        set_option('geolocation_link_to_nav', $_POST['geolocation_link_to_nav']);    
+        
+        set_option('geolocation_disable_images', $_POST['geolocation_disable_images']);    
     }
     
     public function hookDefineAcl($args)

--- a/config_form.php
+++ b/config_form.php
@@ -97,3 +97,16 @@
         </div>
     </div>
 </div>
+
+<div class="field">
+    <div class="two columns alpha">
+        <label for="use_images">Disable thumbnail images on map?</label>    
+    </div>    
+    <div class="inputs five columns omega">
+        <p class="explanation">By default, thumbnail images will be included in the generated KML file and used for the pop up info bubble on the map. Check this option to disable images.</p>
+        <div class="input-block">        
+        <?php echo get_view()->formCheckbox('geolocation_disable_images', true, 
+         array('checked'=>(boolean)get_option('geolocation_disable_images'))); ?>        
+        </div>
+    </div>
+</div>

--- a/views/shared/map/browse.kml.php
+++ b/views/shared/map/browse.kml.php
@@ -27,9 +27,9 @@
             <description><![CDATA[<?php 
             // @since 3/26/08: movies do not display properly on the map in IE6, 
             // so can't use display_files(). Description field contains the HTML 
-            // for displaying the first file (if possible).
-            if (metadata($item, 'has thumbnail')) {
-                echo link_to_item(item_image('thumbnail'), array('class' => 'view-item'));                
+            // for displaying the first file (if possible) unless the user has disabled this feature.
+            if ( (get_option('geolocation_disable_images')==0) && (metadata($item, 'has thumbnail')) ) {
+                echo link_to_item(item_image('thumbnail'), array('class' => 'view-item'));
             }
             ?>]]></description>
             <Point>


### PR DESCRIPTION
This adds an option to disable images in the item-bubble/KML file. 

I have a project where we'll be populating a large map with a few hundred items and would like to keep the size of that request as small as possible.

_(This project will ultimately entail disabling/bypassing the MAX_LOCATIONS_PER_PAGE settings, but that's another issue – one that I haven't really looked at yet)_
