### PR TITLE
Added a route to get all items around one.

### DIFF
--- a/controllers/MapController.php
+++ b/controllers/MapController.php
@@ -6,30 +6,36 @@ class Geolocation_MapController extends Omeka_Controller_AbstractActionControlle
     {
         $this->_helper->db->setDefaultModelName('Item');
     }
-    
+
     public function browseAction()
     {
         $table = $this->_helper->db->getTable();
         $locationTable = $this->_helper->db->getTable('Location');
-        
+
         $params = $this->getAllParams();
         $params['only_map_items'] = true;
         $limit = (int) get_option('geolocation_per_page');
         $currentPage = $this->getParam('page', 1);
 
-        // Only get pagination data for the "normal" page, only get
-        // item/location data for the KML output.
+        // Only get item/location data for the KML output.
         if ($this->_helper->contextSwitch->getCurrentContext() == 'kml') {
             $items = $table->findBy($params, $limit, $currentPage);
             $this->view->items = $items;
             $this->view->locations = $locationTable->findLocationByItem($items);
-        } else {
+        }
+        // Only get pagination data for the "normal" page.
+        else {
+            $item_id = $this->getParam('item_id');
+            if (!empty($item_id)) {
+                $this->view->item = get_record_by_id('Item', $item_id);
+                $this->view->location = $locationTable->findLocationByItem($item_id, true);
+            }
             $this->view->totalItems = $table->count($params);
             $this->view->params = $params;
-        
+
             $pagination = array(
-                'page'          => $currentPage,
-                'per_page'      => $limit,
+                'page' => $currentPage,
+                'per_page' => $limit,
                 'total_results' => $this->view->totalItems
             );
             Zend_Registry::set('pagination', $pagination);

--- a/views/public/map/browse.php
+++ b/views/public/map/browse.php
@@ -1,7 +1,19 @@
-<?php 
+<?php
 queue_css_file('geolocation-items-map');
 
-$title = __('Browse Items on the Map') . ' ' . __('(%s total)', $totalItems);
+$center = array();
+if (isset($item)) {
+    $radius = isset($params['geolocation-radius']) ? $params['geolocation-radius'] : get_option('geolocation_default_radius');
+    $unit = get_option('geolocation_use_metric_distances') ? __('kilometers') :__('miles');
+    $title = __('Browse Items around Item "%s" (%d total, %s %s radius)', link_to_item(null, array(), 'show', $item), $totalItems, $radius, $unit);
+    $center['latitude'] = (double) $location->latitude;
+    $center['longitude'] = (double) $location->longitude;
+    $center['zoomLevel'] = (double) get_option('geolocation_default_zoom_level');
+}
+else {
+    $title = __('Browse Items on the Map (%s total)', $totalItems);
+}
+
 echo head(array('title' => $title, 'bodyclass' => 'map browse'));
 ?>
 
@@ -17,7 +29,7 @@ echo pagination_links();
 ?>
 
 <div id="geolocation-browse">
-    <?php echo $this->googleMap('map_browse', array('list' => 'map-links', 'params' => $params)); ?>
+    <?php echo $this->googleMap('map_browse', array('list' => 'map-links', 'params' => $params), array(), $center); ?>
     <div id="map-links"><h2><?php echo __('Find An Item on the Map'); ?></h2></div>
 </div>
 


### PR DESCRIPTION
Hi,

I need a map that display all items around a map, without browse in search results. So I add one with address `items/map/:item_id` (with pagination if needed). 

In a second time, I think to use it in the hook for items/show/:item_id page in order to avoid to let the item alone on the a map.

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management
