### PR TITLE
Fixed default values for map type and address.

### DIFF
--- a/models/Location.php
+++ b/models/Location.php
@@ -14,6 +14,19 @@ class Location extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_
     public $address;
     
     /**
+     * Executes before the record is saved.
+     */
+    protected function beforeSave($args)
+    {
+        if (is_null($this->map_type)) {
+            $this->map_type = '';
+        }
+        if (is_null($this->address)) {
+            $this->address = '';
+        }
+    }
+
+    /**
      * Validate this location before saving.
      */
     protected function _validate()


### PR DESCRIPTION
Hi,

When geolocation data are imported directly, an error occurs when address and map_type are not set. This patch avoids it.

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management
