### PR TITLE
adds link to get Google Maps API key

### DIFF
--- a/config_form.php
+++ b/config_form.php
@@ -53,7 +53,7 @@
         <label for="api_key"><?php echo __('API Key'); ?></label>
     </div>
     <div class="inputs five columns omega">
-        <p class="explanation"><?php echo __('Google API key for this project. For more information, see: <a target="_blank" href="https://developers.google.com/maps/web/">developers.google.com/maps/web</a>'); ?></p>
+        <p class="explanation"><?php echo __('Google API key for this project. For more information, see: %s','<a target="_blank" href="https://developers.google.com/maps/web/">developers.google.com/maps/web</a>'); ?></p>
         <?php echo $view->formText('api_key', get_option('geolocation_api_key')); ?>
     </div>
 </div>

--- a/config_form.php
+++ b/config_form.php
@@ -53,7 +53,7 @@
         <label for="api_key"><?php echo __('API Key'); ?></label>
     </div>
     <div class="inputs five columns omega">
-        <p class="explanation"><?php echo __('Google API key for this project.'); ?></p>
+        <p class="explanation"><?php echo __('Google API key for this project. For more information, see: <a target="_blank" href="https://developers.google.com/maps/web/">developers.google.com/maps/web</a>'); ?></p>
         <?php echo $view->formText('api_key', get_option('geolocation_api_key')); ?>
     </div>
 </div>


### PR DESCRIPTION
Since an API key is required for the plugin to function properly, it might make sense to label it as such and put it at the top of the config view. But for now I just added a link. Let me know if you want me to submit a new pull request with the above changes. Cheers -- E

PS: It might be handy to add API key info to the [omeka.org documentation](http://omeka.org/codex/Plugins/Geolocation_2.0)  as well. 
