### PR TITLE
Adds range to supported shortcode parameters

### DIFF
--- a/GeolocationPlugin.php
+++ b/GeolocationPlugin.php
@@ -633,6 +633,10 @@ class GeolocationPlugin extends Omeka_Plugin_AbstractPlugin
         if (isset($args['tags'])) {
             $options['params']['tags'] = $args['tags'];
         }
+        
+        if (isset($args['range'])) {
+            $options['params']['range'] = $args['range'];
+        }
 
         $height = $this->_filterCssLength(isset($args['height']) ? $args['height'] : '', '436px');
         $width = $this->_filterCssLength(isset($args['width']) ? $args['width'] : '', '100%');


### PR DESCRIPTION
Adds support for using a range of item ids with the geolocation shortcode.

## Simple use case:
```
[geolocation range=1,2,3,4]
[geolocation range=1-4]
```
## Programmatic use case:
```
$range = implode(',', array_column($items, 'id'));
echo get_view()->shortcodes('[geolocation range='.$range.']');
```