### PR TITLE
Add an empty input validation for the address field

### DIFF
--- a/views/shared/map/input-partial.php
+++ b/views/shared/map/input-partial.php
@@ -37,6 +37,14 @@ jQuery(document).ready(function () {
         event.preventDefault();
         var address = jQuery('#geolocation_address').val();
         var successMessage = jQuery(this).data('successMessage');
+
+        // If no address is entered, alert the user instead of throwing an error later.
+        if (!address) {
+            alert('Please enter an address.');
+            jQuery('#geolocation_address').focus();
+            return;
+        }
+
         geocoder.geocode(address).then(function (coords) {
             var marker = omekaGeolocationForm.setMarker(L.latLng(coords));
             if (marker === false) {


### PR DESCRIPTION
Adds a check for an empty address field before progressing. 
If no address is provided, the user gets alerted with a meaningful message (“Please enter an address.”).