### PR TITLE
Add “Load from metadata” feature to Geolocation input

### DIFF
--- a/views/shared/css/geolocation-marker.css
+++ b/views/shared/css/geolocation-marker.css
@@ -10,6 +10,13 @@
 button#geolocation_find_location_by_address {
     float: none;
 }
+#geolocation_metadata_select {
+    width: 80%;
+}
+#geolocation_metadata_select_label {
+    font-weight: bold;
+    margin-right: 5px;
+}
 
 div#geolocation {
     clear: both;

--- a/views/shared/map/input-partial.php
+++ b/views/shared/map/input-partial.php
@@ -17,6 +17,20 @@ $options = $this->geolocationMapOptions($options);
         <button type="button" name="geolocation_find_location_by_address" id="geolocation_find_location_by_address" data-success-message="<?php echo __('Location found.'); ?>"><?php echo __('Find'); ?></button>
     </div>
 </div>
+
+<div class="metadata-location-picker">
+  <label for="metadata-location-select">Get location from metadata: </label>
+  <select id="metadata-location-select">
+    <!-- TODO: get metadata -->
+    <?php foreach ($metadata as $md): ?>
+      <option value="<?php echo html_escape($md); ?>">
+        <?php echo html_escape($md); ?>
+      </option>
+    <?php endforeach; ?>
+  </select>
+  <button type="button" id="metadata-load-btn">Load</button>
+</div>
+
 <div id="geolocation-sr-alerts" class="sr-only" aria-live="polite" aria-atomic="true"></div>
 <div id="omeka-map-form" class="geolocation-map"></div>
 
@@ -56,6 +70,13 @@ jQuery(document).ready(function () {
             event.preventDefault();
             jQuery('#geolocation_find_location_by_address').click();
         }
+    });
+
+    // Make the metadata load button set the hidden form fields the plugin uses.
+    jQuery('#metadata-load-btn').on('click', function (event) {
+        var metadata = $('#metadata-location-select').val();
+        if (!metadata) return;
+        $('input[name="location]').val(metadata);
     });
 });
 </script>

--- a/views/shared/map/input-partial.php
+++ b/views/shared/map/input-partial.php
@@ -8,6 +8,22 @@ $options = $this->geolocationMapOptions($options);
 <input type="hidden" name="geolocation[zoom_level]" value="<?php echo $zoom; ?>">
 <input type="hidden" name="geolocation[map_type]" value="Leaflet">
 
+<?php
+$metadata = [];
+
+if (($item = get_current_record('Item')) instanceof Item) {
+    $texts = $item->getAllElementTexts();
+
+    foreach ($texts as $textRecord) {
+        $element = $item->getElementById($textRecord->element_id);
+        // Build a label like "Title: My Item Title" and store it in the metadata array:
+        $metadata[] = sprintf('%s: %s', $element->name, substr($tmp = $textRecord->text, 0, 40) . (strlen($tmp) > 40 ? '...' : ''));
+    }
+
+    $metadata = array_unique($metadata);
+}
+?>
+
 <div class="field">
     <div id="location_form" class="two columns alpha">
         <label for="geolocation_address"><?php echo html_escape($label); ?></label>
@@ -16,19 +32,20 @@ $options = $this->geolocationMapOptions($options);
         <input type="text" name="geolocation[address]" id="geolocation_address" value="<?php echo $address; ?>">
         <button type="button" name="geolocation_find_location_by_address" id="geolocation_find_location_by_address" data-success-message="<?php echo __('Location found.'); ?>"><?php echo __('Find'); ?></button>
     </div>
-</div>
 
-<div class="metadata-location-picker">
-  <label for="metadata-location-select">Get location from metadata: </label>
-  <select id="metadata-location-select">
-    <!-- TODO: get metadata -->
-    <?php foreach ($metadata as $md): ?>
-      <option value="<?php echo html_escape($md); ?>">
-        <?php echo html_escape($md); ?>
-      </option>
-    <?php endforeach; ?>
-  </select>
-  <button type="button" id="metadata-load-btn">Load</button>
+    <div class="two columns alpha">
+        <label id="geolocation_metadata_select_label" for="geolocation_metadata_select"><?php echo __('Get location from metadata:');?></label>
+    </div>
+    <div class="inputs five columns omega">
+        <select id="geolocation_metadata_select">
+            <?php foreach ($metadata as $md): ?>
+            <option value="<?php echo html_escape($md); ?>">
+                <?php echo html_escape($md); ?>
+            </option>
+            <?php endforeach; ?>
+        </select>
+        <button type="button" id="geolocation_metadata_load_btn"><?php echo __('Load');?></button>
+    </div>
 </div>
 
 <div id="geolocation-sr-alerts" class="sr-only" aria-live="polite" aria-atomic="true"></div>
@@ -73,10 +90,18 @@ jQuery(document).ready(function () {
     });
 
     // Make the metadata load button set the hidden form fields the plugin uses.
-    jQuery('#metadata-load-btn').on('click', function (event) {
-        var metadata = $('#metadata-location-select').val();
-        if (!metadata) return;
-        $('input[name="location]').val(metadata);
+    jQuery('#geolocation_metadata_load_btn').on('click', function (event) {
+        event.preventDefault();
+
+        // Get the raw selected option text, e.g. "Title: My Awesome Place"
+        var selected = jQuery('#geolocation_metadata_select').val();
+        if (!selected) return;
+
+        // Split off the part after the first ": "
+        var parts = selected.split(': ');
+        var address = parts.slice(1).join(': ');
+
+        jQuery('#geolocation_address').val(address).trigger('change');
     });
 });
 </script>


### PR DESCRIPTION
Adds a new "get location from metadata" dropdown and Load button in the input form, allowing users to select an existing metadata field on an item (e.g., Title, Location ...) and automatically populate the geolocation address input with its text.

Thats what it looks like:
![geolocation](https://github.com/user-attachments/assets/7ee42af4-e45e-4d4d-b1b5-e84d39bb4de3)
