### PR TITLE
Add option to toggle display of single item map

### DIFF
--- a/GeolocationPlugin.php
+++ b/GeolocationPlugin.php
@@ -65,6 +65,7 @@ class GeolocationPlugin extends Omeka_Plugin_AbstractPlugin
         set_option('geolocation_use_metric_distances', '0');
         set_option('geolocation_basemap', self::DEFAULT_BASEMAP);
         set_option('geolocation_geocoder', self::DEFAULT_GEOCODER);
+        set_option('geolocation_item_map_enable', '1');
     }
 
     public function hookUninstall()
@@ -84,6 +85,7 @@ class GeolocationPlugin extends Omeka_Plugin_AbstractPlugin
         delete_option('geolocation_mapbox_access_token');
         delete_option('geolocation_mapbox_map_id');
         delete_option('geolocation_cluster');
+        delete_option('geolocation_item_map_enable');
 
         // This is for older versions of Geolocation, which used to store a Google Map API key.
         delete_option('geolocation_gmaps_key');
@@ -175,6 +177,7 @@ class GeolocationPlugin extends Omeka_Plugin_AbstractPlugin
         set_option('geolocation_default_latitude', $_POST['default_latitude']);
         set_option('geolocation_default_longitude', $_POST['default_longitude']);
         set_option('geolocation_default_zoom_level', $_POST['default_zoom_level']);
+        set_option('geolocation_item_map_enable', $_POST['geolocation_item_map_enable']);
         set_option('geolocation_item_map_width', $_POST['item_map_width']);
         set_option('geolocation_item_map_height', $_POST['item_map_height']);
         $perPage = (int)$_POST['per_page'];
@@ -301,6 +304,7 @@ class GeolocationPlugin extends Omeka_Plugin_AbstractPlugin
 
     public function hookPublicItemsShow($args)
     {
+        if(!get_option('geolocation_item_map_enable')) return;
         $view = $args['view'];
         $item = $args['item'];
         $location = $this->_db->getTable('Location')->findLocationByItem($item, true);

--- a/config_form.php
+++ b/config_form.php
@@ -199,6 +199,18 @@
 <legend><?php echo __('Item Map Settings'); ?></legend>
 <div class="field">
     <div class="two columns alpha">
+        <label for="geolocation_item_map_enable"><?php echo __('Enable Item Map'); ?></label>
+    </div>
+    <div class="inputs five columns omega">
+        <p class="explanation"><?php echo __('Display map on the items/show page.'); ?></p>
+        <?php
+        echo $view->formCheckbox('geolocation_item_map_enable', true,
+            array('checked' => (boolean) get_option('geolocation_item_map_enable')));
+        ?>
+    </div>
+</div>
+<div class="field">
+    <div class="two columns alpha">
         <label for="item_map_width"><?php echo __('Width for Item Map'); ?></label>
     </div>
     <div class="inputs five columns omega">


### PR DESCRIPTION
This PR adds a config option allowing admins to control whether the item map is displayed on single item records. This gives more flexibility to theme developers who might want to relocate the map within the layout without (re)moving  `fire_plugin_hook` or who simply want to use Geolocation without displaying the item map for whatever reason. 